### PR TITLE
Important _validate_offset fix and some optional "feature bloat"

### DIFF
--- a/lib/FFmpeg/Thumbnail.pm
+++ b/lib/FFmpeg/Thumbnail.pm
@@ -140,10 +140,9 @@ The time in the video (in seconds) at which to grab the thumbnail. Defaults
 to 0.
 
 Note that ffmpeg has two seek modes, depending on the -ss option being used as
-an input file option or an output file option. The latter is slower but more
-accurate and due to the internal layout of this module the slower mode is
-currently used here. So be aware of the fact that with bigger videos, and
-seek offsets further into the file, thumbnailing may become unnecessarily slow.
+an input file option or an output file option. The first one is less accurate
+but used here as it's much faster with long videos and seek offsets further
+into the file.
 
 =cut
 
@@ -280,17 +279,19 @@ sub create_thumbnail {
     }
 
     $self->output_file( $filename || $self->filename );
+    $self->ffmpeg->infile_options(
+        '-ss'      => $off_val,     # position, as input file option to have fast seeks
+    );
     $self->options(
         '-y',                       # overwrite files
         '-f'       => $self->file_format,     # force format
         '-vframes' => 1,            # number of frames to record
-        '-ss'      => $off_val,     # position
 #       '-noaccurate_seek',         # we can't pass -ss as an input option yet, and sadly only very recent ffmpegs offer this switch
         '-s'       => $self->output_width.'x'.$self->output_height,    # sets frame size
         @aspect_strategy,
         '-loglevel'=> 'quiet',      # tones down log output
     );
-    return $self->hide_log_output ? capture { $self->ffmpeg->exec() } : $self->ffmpeg->exec() ;
+    return $self->hide_log_output ? capture { $self->ffmpeg->execute() } : $self->ffmpeg->execute() ;
 }
 
 

--- a/lib/FFmpeg/Thumbnail.pm
+++ b/lib/FFmpeg/Thumbnail.pm
@@ -210,14 +210,13 @@ has 'output_height' => (
 =head2 aspect_strategy
 
 How to treat video aspect ratios. If you pass I<crop>, the input video
-frame will be cropped to fit into the set width x height.
+frame will be cropped to fit into the set width x height. When you pass in
+I<letterbox>, the video frame will be resized and letterboxed to fit into
+the set dimensions.
 Default is I<undef>: stretch or squeeze video according to output_width and
 output_height.
 
 =cut
-
-# TODO: "If you pass in I<letterbox>, the video frame will be resized and
-# letterboxed to fit into the set dimensions."
 
 has 'aspect_strategy' => (
     is => 'rw',
@@ -276,9 +275,8 @@ sub create_thumbnail {
     if($self->aspect_strategy() && $self->aspect_strategy() eq 'crop'){
         @aspect_strategy = ('-vf', "crop=(ih*". ($self->output_width / $self->output_height) ."):ih");
     }elsif($self->aspect_strategy() && $self->aspect_strategy() eq 'letterbox'){
-	# https://kevinlocke.name/bits/2012/08/25/letterboxing-with-ffmpeg-avconv-for-mobile/
-	# TODO: couldn't get this to work, something with options()'s interpolation...
-        @aspect_strategy = ('-vf', "scale=iw*sar*min(". $self->output_width ."/(iw*sar)\,". $self->output_height ."/ih):ih*min(". $self->output_width ."/(iw*sar)\,". $self->output_height ."/ih),pad=". $self->output_width .":". $self->output_height .":(ow-iw)/2:(oh-ih)/2");
+	# filter_graph from: https://kevinlocke.name/bits/2012/08/25/letterboxing-with-ffmpeg-avconv-for-mobile/
+        @aspect_strategy = ('-vf', "scale=iw*sar*min(". $self->output_width .'/(iw*sar)\,'. $self->output_height ."/ih):ih*min(". $self->output_width .'/(iw*sar)\,'. $self->output_height ."/ih),pad=". $self->output_width .":". $self->output_height .":(ow-iw)/2:(oh-ih)/2");
     }
 
     $self->output_file( $filename || $self->filename );

--- a/lib/FFmpeg/Thumbnail.pm
+++ b/lib/FFmpeg/Thumbnail.pm
@@ -134,9 +134,16 @@ has 'filename' => (
     default => '/tmp/thumbnail.png',
 );
 
-=head2 default_offset
+=head2 offset
 
-The time in the video (in seconds) at which to grab the thumbnail
+The time in the video (in seconds) at which to grab the thumbnail. Defaults
+to 0.
+
+Note that ffmpeg has two seek modes, depending on the -ss option being used as
+an input file option or an output file option. The latter is slower but more
+accurate and due to the internal layout of this module the slower mode is
+currently used here. So be aware of the fact that with bigger videos, and
+seek offsets further into the file, thumbnailing may become unnecessarily slow.
 
 =cut
 
@@ -148,7 +155,10 @@ has 'offset' => (
 
 =head2 file_format
 
-Ffmpeg output file format, used by the '-f' argument. Defaults to 'image2' (png). 'mjpeg' (jpeg) is also known to work.
+Ffmpeg output file muxer, passed to the '-f' argument. Defaults to 'image2',
+ffmpeg's standard image file muxer, which is able to write various image formats
+based on the output file extension you choose. When you write a file with no
+file suffix, image2 defaults to jpeg. 'mjpeg' is also known to work.
 
 =cut
 has 'file_format' => (
@@ -311,7 +321,8 @@ Checks $offset to make sure that it is numeric and <= $self->duration.
 =cut
 sub _validate_offset {
     my ($self, $offset ) = @_;
-    return $offset && looks_like_number( $offset ) and $offset <= $self->duration  ;
+
+    return ($offset && looks_like_number( $offset ) && $offset <= $self->duration) ? 1 : 0;
 }
 
 


### PR DESCRIPTION
Hi,
me again with a pull request. I've found that _validate_offset was not actually validating, but doing a binary operation instead and thus always returning true - resulting in failed thumbnailing with videos where runtime < offset.
Also I've added offset_strategy() which overrides a fixed offset and (currently) allows a user to extract thumbs from the "middle" of videos. In relation with that I found that due to the way commands are passed to ffmpeg/avconv, the module currently always uses the slow/accurate seek mode (which can take long on larger videos), with -ss as an output option:

>   -ss position (input/output)
>           When used as an input option (before "-i"), seeks in this input
>           file to position. When used as an output option (before an output
>           filename), decodes but discards input until the timestamps reach
>           position. This is slower, but more accurate.

~~I can't fully wrap my head around how FFmpeg::Command handles execution and parameter passing to ffmpeg, thus I couldn't fix that (- just like the filter graph in the previous pull-request). The fix would be to pass in -ss before -i, probably by using FFmpeg::Command's infile_options() instead of options() but that would clash in some way with probing the file and constucting _build_ffmpeg() ...
You, or someone else looking, may have an idea.~~
I fixed that by passing -ss separately to infile_options().

Apart from that, feel free to cherry-pick as I understand that adding yet another feature (offset_strategy) might be a bit much or not in line with your idea of this module.
